### PR TITLE
fixed minute display in event details on webapge

### DIFF
--- a/ics-client/client.py
+++ b/ics-client/client.py
@@ -135,7 +135,7 @@ class ICSClient:
         str_event_data = {}
         for key, value in data.items():
             if isinstance(value, datetime):
-                str_event_data[key] = value.strftime("%b %d, %Y %l%p")
+                str_event_data[key] = value.strftime("%b %d, %Y %l:%M%p")
             elif isinstance(value, date):
                 str_event_data[key] = value.strftime("%b %d, %Y")
             else:

--- a/ics-client/tests/test_client.py
+++ b/ics-client/tests/test_client.py
@@ -148,8 +148,8 @@ class TestICSClient(unittest.TestCase):
         }
         formatted = self.client.format_event_data(data)
         self.assertEqual(formatted["name"],"Dinner with Friends")
-        self.assertEqual(formatted["start"], "Apr 23, 2025  6PM")
-        self.assertEqual(formatted["end"], "Apr 23, 2025  8PM")
+        self.assertEqual(formatted["start"], "Apr 23, 2025  6:00PM")
+        self.assertEqual(formatted["end"], "Apr 23, 2025  8:00PM")
         
     def test_format_event_data_date_only(self):
         """


### PR DESCRIPTION
When event time was specified as 9:30am, the webpage was showing 9AM but ics file still had the correct time. Fixed this bug.